### PR TITLE
Enable multiple tls hostnames

### DIFF
--- a/charts/magistrala/templates/ingress.yaml
+++ b/charts/magistrala/templates/ingress.yaml
@@ -37,7 +37,9 @@ spec:
 {{- if .Values.ingress.tls }}
   tls:
     - hosts:
-        - {{ .Values.ingress.tls.hostname }}
+        {{- range .Values.ingress.tls.hosts }}
+        - {{ . | quote }}
+        {{- end }}
       secretName: {{ .Values.ingress.tls.secret }}
 {{- end }}
 ---
@@ -216,7 +218,9 @@ spec:
 {{- if .Values.ingress.tls }}
   tls:
     - hosts:
-        - {{ .Values.ingress.tls.hostname }}
+        {{- range .Values.ingress.tls.hosts }}
+        - {{ . | quote }}
+        {{- end }}
       secretName: {{ .Values.ingress.tls.secret }}
 {{- end }}
 ---
@@ -279,7 +283,9 @@ spec:
 {{- if .Values.ingress.tls }}
   tls:
     - hosts:
-        - {{ .Values.ingress.tls.hostname }}
+        {{- range .Values.ingress.tls.hosts }}
+        - {{ . | quote }}
+        {{- end }}
       secretName: {{ .Values.ingress.tls.secret }}
 {{- end }}
 ---

--- a/charts/magistrala/values.yaml
+++ b/charts/magistrala/values.yaml
@@ -23,11 +23,6 @@ ingress:
   enabled: true
   annotations: {}
   labels: {}
-  # Uncomment this block for TLS support in public ingress
-  # hostname: ""
-  # tls:
-  #   hostname: ""
-  #   secret: "magistrala-server"
 
 nginxInternal:
   image:


### PR DESCRIPTION
Enables setting multiple hosts for ingress tls.

This will allow us to terminate tls for canopy.janga.la and cloud.janga.la.